### PR TITLE
Update download.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Aria2 Recursive Download
+
+Forked from: https://github.com/Cartmanishere/Aria2-Recursive-Download
+I modified download.py so that it now dynamically maximizes speed for the client connection.
+See pull request in original repo for more details.
+
+
+# Original Docs
+
 A simple scraper and bash script combination to download open directories recursively using aria2 instead of wget.
 
 I use python BeautifulSoup to scrape an open directory and make a directory structure with relevant link to files stored in links.txt

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Aria2 Recursive Download
 
 Forked from: https://github.com/Cartmanishere/Aria2-Recursive-Download
+
 I modified download.py so that it now dynamically maximizes speed for the client connection.
+
 See pull request in original repo for more details.
+
 
 
 # Original Docs

--- a/download.py
+++ b/download.py
@@ -1,7 +1,7 @@
 import os
 
 def download():
-	os.system("aria2c --file-allocation=none -c --auto-file-renaming=false -i links.txt")
+	os.system("aria2c --optimize-concurrent-downloads true -j 5000 -x 5 --file-allocation=none -c --auto-file-renaming=false -i links.txt")
 
 folders = [ x[0] for x in os.walk(os.getcwd()) ]
 folders.sort()


### PR DESCRIPTION
Maximize concurrent downloads for user's connection. -j set for 5000 only to prevent limitation from being imposed on --optimize-concurrent-downloads. -x raised from 1 to 5 to increase simultaneous connections per individual file.

From man aria2c:
 --optimize-concurrent-downloads [true|false|\<A\>:\<B\>]
              Optimizes  the  number  of concurrent downloads according to the bandwidth avail‐
              able. aria2 uses the download speed observed in the previous downloads  to  adapt
              the  number  of  downloads  launched  in parallel according to the rule N = A + B
              Log10(speed in Mbps). The coefficients A and B can be customized  in  the  option
              arguments  with A and B separated by a colon. The default values (A=5, B=25) lead
              to using typically 5 parallel downloads on 1Mbps networks and above 50 on 100Mbps
              networks.  The number of parallel downloads remains constrained under the maximum
              defined by the --max-concurrent-downloads parameter.  Default: false